### PR TITLE
fix(workflow): metrics アクションを book000/metrics フォークに変更

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate SVG metrics
-        uses: gh-metrics/metrics@master
+        uses: book000/metrics@master
         with:
           # Your GitHub token
           token: ${{ secrets.METRICS_TOKEN }}


### PR DESCRIPTION
## 概要

`github-metrics.svg` で `Recent coding habits` と `Recent activity` セクションに「Unexpected error」が表示され続けている問題 (#106) を修正。

## 原因

`gh-metrics/metrics` が Maintenance Mode であり、GitHub Events API が PushEvent の `payload.commits` フィールドを省略した場合（大量コミット時の truncation など）に `activity` プラグインと `habits` プラグインがクラッシュしていた。

- **activity プラグイン**: `payload.commits` が `undefined` 時に `.filter()` が失敗
- **habits プラグイン**: `payload.commits` が `undefined` 時に `flatMap` が `undefined` を展開し、後続の分割代入が失敗

## 対応内容

`gh-metrics/metrics` の代わりに、上記バグを修正した `book000/metrics` フォーク ([book000/metrics#1](https://github.com/book000/metrics/pull/1)) を使用するよう変更。

```diff
- uses: gh-metrics/metrics@master
+ uses: book000/metrics@master
```

## 注意事項

このPRは [book000/metrics#1](https://github.com/book000/metrics/pull/1) がマージされた後にマージしてください。

## テスト計画

- [ ] [book000/metrics#1](https://github.com/book000/metrics/pull/1) がマージされていること
- [ ] ワークフローを手動実行して `github-metrics.svg` が正常に生成されること
- [ ] `Recent coding habits` と `Recent activity` セクションに「Unexpected error」が表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)