### PR TITLE
fix(workflow): git が不足する book000/metrics Docker イメージの ENOENT エラーを回避

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -11,7 +11,15 @@ on:
 jobs:
   github-metrics:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.METRICS_TOKEN }}
+
       - name: Generate SVG metrics
         uses: book000/metrics@master
         with:
@@ -24,17 +32,47 @@ jobs:
           base: header, activity, community
           config_timezone: Asia/Tokyo
           repositories_affiliations: owner, collaborator, organization_member
-          
+
           plugin_habits: yes
           plugin_habits_from: 200
           plugin_habits_days: 14
           plugin_habits_facts: yes
           plugin_habits_charts: yes
           plugin_habits_trim: yes
-          
+
           plugin_activity: yes
           plugin_activity_limit: 5
           plugin_activity_days: 14
           plugin_activity_filter: all
           plugin_activity_visibility: public
           plugin_activity_timestamps: yes
+
+          # book000/metrics の Docker イメージに git が含まれていないため、
+          # output_action を none にして後続ステップで手動コミットする
+          # 参照: https://github.com/book000/metrics/pull/5
+          output_action: none
+
+      - name: Commit and push generated metrics
+        run: |
+          RENDERS_DIR="/metrics_renders"
+          SVG_FILE="github-metrics.svg"
+
+          if [ ! -f "${RENDERS_DIR}/${SVG_FILE}" ]; then
+            echo "::error::Rendered SVG not found at ${RENDERS_DIR}/${SVG_FILE}"
+            exit 1
+          fi
+
+          cp "${RENDERS_DIR}/${SVG_FILE}" "./${SVG_FILE}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add "${SVG_FILE}"
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Auto-generated metrics for run #${{ github.run_id }}"
+            # 並行 push による non-fast-forward を避けるためリベースしてから push する
+            git pull --rebase origin ${{ github.ref_name }}
+            git push
+          fi


### PR DESCRIPTION
## 概要

github-metrics ワークフローが毎時失敗しており、21 件以上のエラーが積み上がっています。

### エラー内容

```
GitError: Error: spawn git ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:285:19)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRijections (node:internal/process/task_queues:82:21)
    at Object.action (file:///metrics/node_modules/simple-git/dist/esm/index.js:3824:25)
```

## 根本原因

`book000/metrics` フォークの Docker イメージに `git` バイナリが含まれていないことが原因です。

`source/app/action/index.mjs` では `simple-git (sgit)` を使用して `git hashObject` でファイルの SHA を計算していますが、Docker コンテナ内に `git` バイナリが存在しないためエラーが発生しています。

これはコミット `8ec83bf` (`perf(docker): Ruby/Deno を削除してビルド時間を短縮`) で Ruby・Deno と共に `git` も誤って削除されたことが原因です。

### Docker イメージ側の根本修正

`book000/metrics` リポジトリの Dockerfile に `git` を追加する PR を作成済みです：

**https://github.com/book000/metrics/pull/5**

## 本 PR での対処

`book000/metrics#5` がマージされるまでの間、ワークフロー側で `output_action: none` を設定し、Docker コンテナ内での git 操作を回避します。代わりに後続ステップで手動コミット・プッシュを行います。

## 変更内容

### `metrics.yml`

- `actions/checkout@v4` ステップを追加（リポジトリのチェックアウト）
- `output_action: none` を追加（Docker 内の git 操作を回避）
- 「Commit and push generated metrics」ステップを追加
  - `/metrics_renders/github-metrics.svg` をリポジトリにコピー
  - `git add` → `git commit` → `git pull --rebase` → `git push` の順で実行
  - 並行 push による non-fast-forward を防ぐため push 前にリベース

### 注意事項

- `output_action: none` 設定でもレンダリング結果は `/metrics_renders/` (ホスト) に保存されます
- 新しいコミットメッセージ `Auto-generated metrics for run #NNN` は `book000/metrics` の skip パターン `/Auto-generated metrics for run #\d+/` にマッチするため、push トリガーでの無限ループは発生しません