### PR TITLE
fix(metrics): ボットの push による CI 再トリガーとエラーを解消する

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,4 +1,4 @@
-# Visit https://github.com/book000/metrics/blob/master/action.yml for full reference
+# 詳細は https://github.com/book000/metrics/blob/master/action.yml を参照
 name: Metrics
 on:
   # スケジュール実行（毎時）
@@ -20,7 +20,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.METRICS_TOKEN }}
+          # git push 時のアクターを github-actions[bot] にするため GITHUB_TOKEN を使用する
+          # METRICS_TOKEN（PAT）を使うと push がトークン所有者名になり if 条件が機能しない
+          token: ${{ github.token }}
 
       - name: Generate SVG metrics
         uses: book000/metrics@master

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,16 +1,18 @@
-# Visit https://github.com/lowlighter/metrics/blob/master/action.yml for full reference
+# Visit https://github.com/book000/metrics/blob/master/action.yml for full reference
 name: Metrics
 on:
-  # Schedule updates (each hour)
+  # スケジュール実行（毎時）
   schedule:
     - cron: '00 * * * *'
-  # Lines below let you run workflow manually and on each commit
+  # 手動実行と master/main ブランチへの push でも実行
   workflow_dispatch:
   push:
     branches: [ master, main ]
 jobs:
   github-metrics:
     runs-on: ubuntu-latest
+    # ボットのコミットによる push での再トリガーを防ぐ（無限ループ回避）
+    if: "!(github.event_name == 'push' && github.actor == 'github-actions[bot]')"
     permissions:
       contents: write
     steps:
@@ -71,8 +73,8 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "Auto-generated metrics for run #${{ github.run_id }}"
+            git commit -m "Update github-metrics.svg - [Skip GitHub Action]"
             # 並行 push による non-fast-forward を避けるためリベースしてから push する
             git pull --rebase origin ${{ github.ref_name }}
-            git push
+            git push origin ${{ github.ref_name }}
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@
 - **目的**: GitHub プロフィールリポジトリ。個人プロフィールの表示と、GitHub metrics の自動更新、monthly update issue の自動作成を行う。
 - **主な機能**:
   - プロフィール README.md の管理
-  - GitHub metrics SVG の毎時自動更新（gh-metrics/metrics（lowlighter/metrics ベース）を使用）
+  - GitHub metrics SVG の毎時自動更新（book000/metrics（lowlighter/metrics ベース）を使用）
   - monthly update issue の自動作成（book000, tomacheese, jaoafa の Renovate PR リスト含む）
 
 ## 重要ルール
@@ -131,6 +131,8 @@ gh workflow run monthly-update.yml
 
 3. **.github/workflows/metrics.yml**: metrics 自動更新ワークフロー
    - 毎時実行して github-metrics.svg を更新
+   - book000/metrics を使用し、output_action: none で手動コミット
+   - github-actions[bot] による push は再トリガーを防ぐためスキップ
 
 4. **.github/workflows/monthly-update.yml**: monthly update issue 自動作成ワークフロー
    - 毎月 1 日に実行して、Renovate PR リストを含む issue を作成


### PR DESCRIPTION
## 概要

`metrics.yml` ワークフローで高頻度に CI エラーが発生していた問題を解消します。

## 原因の分析

以下の連鎖が CI エラーの原因でした：

1. スケジュール実行でメトリクス SVG が生成され、master ブランチにコミット・プッシュ
2. この push が `on: push` トリガーによりワークフローを再実行
3. 再実行時、アクションが SVG 生成をスキップ
4. 「Commit and push generated metrics」ステップが SVG ファイルが存在しないまま実行され、`exit 1` で失敗

## 変更内容

### 1. ボットの push による再トリガーを防ぐ job 条件の追加（主要修正）

```yaml
if: "!(github.event_name == 'push' && github.actor == 'github-actions[bot]')"
```

- `github-actions[bot]` が行った push イベントの場合、ジョブ全体をスキップ
- schedule・workflow_dispatch・人間による push では引き続き実行される

### 2. checkout トークンを `GITHUB_TOKEN` に変更

- `METRICS_TOKEN`（PAT）で checkout すると git push がトークン所有者名になり、`if` 条件が機能しない
- `${{ github.token }}`（GITHUB_TOKEN）に変更することで push が `github-actions[bot]` として行われ、条件が正しく機能する
- メトリクス API アクセスには引き続き `METRICS_TOKEN` を使用

### 3. コミットメッセージを既存履歴と一致する形式に変更

`Auto-generated metrics for run #<id>` → `Update github-metrics.svg - [Skip GitHub Action]`

### 4. `git push` に明示的なリモート・ブランチ指定を追加

`git push` → `git push origin ${{ github.ref_name }}`

### 5. 参照コメントを日本語に更新

ファイル先頭コメントを日本語化し、参照先を `book000/metrics` の action.yml に更新。

### 6. CLAUDE.md の更新

- `gh-metrics/metrics` → `book000/metrics` に更新
- metrics.yml の動作説明に再トリガー防止・GITHUB_TOKEN 利用・手動コミット方針を追記

- Closes #114